### PR TITLE
Use pytest-shell fixture

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,10 @@
+def test_err_and_used(bash):
+    bash.auto_return_code_error = False
+    script = """source ./gukebox.sh
+trap - ERR
+set +e
+f(){ gb::used VAR; gb::err 5; echo $?; }
+f
+"""
+    ret = bash.send(script)
+    assert ret.strip().splitlines()[-1] == "5"

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -22,3 +22,24 @@ def test_run_command_parallel(bash):
     duration = end_time - start_time
     assert len(res) == 17
     assert int(duration) == running_time
+
+
+def test_run_command_file_parallel(bash, tmp_path):
+    job_file = tmp_path / "jobs.txt"
+    job_file.write_text("echo one\necho two\necho three\n")
+    bash.send("source ./gukebox.sh")
+    output = bash.send(f"gb::run_command_file_parallel 2 {job_file}")
+    assert 'START: echo one' in output
+    assert 'START: echo two' in output
+    assert 'START: echo three' in output
+
+
+def test_get_self_fd_and_mkpipe(bash):
+    bash.send("source ./gukebox.sh")
+    fd_list = bash.send("gb::get_self_fd | head -n 3").splitlines()
+    assert '0' in fd_list and '1' in fd_list and '2' in fd_list
+    output = bash.send(
+        "gb::mkpipe; echo $GB_FREE_FD; ls /proc/$$/fd/$GB_FREE_FD; exec {GB_FREE_FD}<&-"
+    ).splitlines()
+    assert output[0].isdigit()
+    assert "/proc/" in output[1]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,20 @@
+import re
+
+
+def test_retry_with_constant(bash):
+    bash.send("source ./gukebox.sh")
+    bash.send("i=0")
+    cmd = "if ((i==1)); then true; else i=$((i+1)); false; fi"
+    output = bash.send(f"gb::retry_with_constant 2 0 '{cmd}' && echo done")
+    assert output.endswith('done')
+    assert re.search(r'Retry 1/2 exited 1, retrying in 0 seconds', output)
+
+
+def test_retry(bash):
+    bash.send("source ./gukebox.sh")
+    bash.send("sleep() { :; }")
+    bash.send("i=0")
+    cmd = "if ((i==1)); then true; else i=$((i+1)); false; fi"
+    output = bash.send(f"gb::retry 2 '{cmd}' && echo done")
+    assert output.endswith('done')
+    assert re.search(r'Retry 1/2 exited 1, retrying in [0-9]+ seconds', output)

--- a/tests/test_util_extra.py
+++ b/tests/test_util_extra.py
@@ -1,0 +1,38 @@
+def test_find_all_dir(bash, tmp_path):
+    src = tmp_path / "src"
+    (src / "a/b").mkdir(parents=True)
+    (src / ".hidden").mkdir()
+    bash.send("source ./gukebox.sh")
+    res_all = bash.send(f"gb::find_all_dir {src} no").splitlines()
+    res_no_hidden = bash.send(f"gb::find_all_dir {src} yes").splitlines()
+    assert any(str(src / ".hidden") == p for p in res_all)
+    assert all(".hidden" not in p for p in res_no_hidden)
+
+
+def test_copy_tree_struct_and_fast_delete(bash, tmp_path):
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    (src / "a/b").mkdir(parents=True)
+    (src / ".hidden/d").mkdir(parents=True)
+    dst.mkdir()
+    bash.send("source ./gukebox.sh")
+    bash.send(f"gb::copy_tree_struct {src} {dst} yes")
+    assert (dst / "src/a/b").is_dir()
+    assert not (dst / ".hidden").exists()
+
+    # create files and then fast delete
+    (dst / "src" / "file1").write_text("x")
+    (dst / "src" / "a" / "file2").write_text("y")
+    bash.send(f"gb::fast_delete {dst}")
+    assert list(dst.rglob("*")) == []
+
+
+def test_system_utils(bash):
+    bash.send("source ./gukebox.sh")
+    version = bash.send("gb::get_bash_version")
+    assert version
+    ret = bash.send(f"gb::check_bash_version {version} && echo ok")
+    assert ret == "ok"
+    core = int(bash.send("gb::get_core_num"))
+    assert core >= 1
+


### PR DESCRIPTION
## Summary
- remove custom bash fixture and rely on pytest-shell's builtin `bash`
- add tests for `gb::retry`, `gb::run_command_file_parallel`, and other shell helpers

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab51d2d6c8329b9e759285bfe389d